### PR TITLE
disable turning penalties for bicycle and car, do not apply perceived length multiplier for bicycle routing

### DIFF
--- a/src/main/java/com/conveyal/r5/streets/BasicTraversalTimeCalculator.java
+++ b/src/main/java/com/conveyal/r5/streets/BasicTraversalTimeCalculator.java
@@ -20,10 +20,11 @@ public class BasicTraversalTimeCalculator implements TraversalTimeCalculator {
     // These are all specified for drive-on-right countries, and reversed in drive-on-left countries.
     // TODO re-express as "turn against traffic" and "turn with traffic" to make this less confusing.
 
-    public static final int LEFT_TURN = 30;
+    // disable all turning penalties after implementing edge traversal times
+    public static final int LEFT_TURN = 0;
     public static final int STRAIGHT_ON = 0;
-    public static final int RIGHT_TURN = 10;
-    public static final int U_TURN = 90; // penalize U turns extremely heavily
+    public static final int RIGHT_TURN = 0;
+    public static final int U_TURN = 0;
 
     public boolean driveOnRight; // TODO instead of a field, this should be a different implementation class
 

--- a/src/main/java/com/conveyal/r5/streets/LaDotBikeCostSupplier.java
+++ b/src/main/java/com/conveyal/r5/streets/LaDotBikeCostSupplier.java
@@ -19,7 +19,7 @@ public class LaDotBikeCostSupplier implements SingleModeTraversalTimes.Supplier 
     public double perceivedLengthMultipler () {
         // disable all of these extra evaluations, since we have edge-level traversal speeds
         return 1;
-
+        /*
         // Original formula:
         // distance + distance * (bike_blvd_penalty + bike_path_penalty + slope_penalty + no_bike_penalty)
         // Start at unity
@@ -49,6 +49,7 @@ public class LaDotBikeCostSupplier implements SingleModeTraversalTimes.Supplier 
         factor += tags.slopePercent4to6 * 1.23;
         factor += tags.slopePercent6plus * 3.239;
         return factor;
+        */
     }
 
     @Override

--- a/src/main/java/com/conveyal/r5/streets/LaDotBikeCostSupplier.java
+++ b/src/main/java/com/conveyal/r5/streets/LaDotBikeCostSupplier.java
@@ -17,10 +17,14 @@ public class LaDotBikeCostSupplier implements SingleModeTraversalTimes.Supplier 
 
     @Override
     public double perceivedLengthMultipler () {
+        // disable all of these extra evaluations, since we have edge-level traversal speeds
+        return 1;
+
         // Original formula:
         // distance + distance * (bike_blvd_penalty + bike_path_penalty + slope_penalty + no_bike_penalty)
         // Start at unity
         double factor = 1;
+
         // Reduce cost if bike infrastructure is present.
         // TODO define constants for all bonuses and costs
         if (tags.bikeInfrastructure == BOULEVARD) {
@@ -49,12 +53,15 @@ public class LaDotBikeCostSupplier implements SingleModeTraversalTimes.Supplier 
 
     @Override
     public int turnTimeSeconds (SingleModeTraversalTimes.TurnDirection turnDirection) {
-        return (int)(computeBikeTurnCostM(turnDirection) / STANDARD_BIKE_SPEED_M_PER_SEC);
+        // disable all of these extra evaluations, since we have edge-level traversal speeds
+        return (int) 0;
+        // return (int)(computeBikeTurnCostM(turnDirection) / STANDARD_BIKE_SPEED_M_PER_SEC);
     }
 
     /** @return the cost in effective meters of turning off the given edge in the given direction on a bicycle. */
     private int computeBikeTurnCostM (SingleModeTraversalTimes.TurnDirection turnDirection) {
         int penaltyMeters = 0;
+
         // Stop signs and traffic lights add a penalty to all directions.
         if (tags.controlType == STOP) {
             penaltyMeters += 6;


### PR DESCRIPTION
closes #14 